### PR TITLE
Feature/headers in events

### DIFF
--- a/maven-push.gradle
+++ b/maven-push.gradle
@@ -35,7 +35,7 @@ def getSnapshotRepositoryUrl() {
 }
 
 project.ext.set("props", new Properties())
-if (file("push.properties").exists()) {
+if (new File("push.properties").exists()) {
     props.load(new FileInputStream("push.properties"))
 }
 

--- a/src/main/java/com/byoutline/eventcallback/EventCallback.java
+++ b/src/main/java/com/byoutline/eventcallback/EventCallback.java
@@ -139,7 +139,7 @@ public class EventCallback<S, E> implements Callback<S> {
         boolean postNullResponse = true;
         informSharedSuccessHandlers(result);
         informStatusCodeListener(response);
-        postHelper.executeResponseActions(onSuccessActions, result, sessionChecker.isSameSession(), postNullResponse);
+        postHelper.executeResponseActions(onSuccessActions, result, response, sessionChecker.isSameSession(), postNullResponse);
     }
 
     @Override
@@ -147,7 +147,7 @@ public class EventCallback<S, E> implements Callback<S> {
         boolean postNullResponse = false;
         E convertedError = RetrofitErrorConverter.<E>getAsClassOrNull(validationErrorTypeToken, error);
         informStatusCodeListener(error.getResponse());
-        postHelper.executeResponseActions(onErrorActions, convertedError, sessionChecker.isSameSession(), postNullResponse);
+        postHelper.executeResponseActions(onErrorActions, convertedError, error.getResponse(), sessionChecker.isSameSession(), postNullResponse);
     }
 
     /**

--- a/src/main/java/com/byoutline/eventcallback/EventCallbackBuilder.java
+++ b/src/main/java/com/byoutline/eventcallback/EventCallbackBuilder.java
@@ -6,14 +6,9 @@ import com.byoutline.eventcallback.internal.actions.ResultEvents;
 import com.byoutline.eventcallback.internal.actions.ScheduledActions;
 import com.google.gson.reflect.TypeToken;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import javax.annotation.Nonnull;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Creates complete instance of {@link EventCallback} using fluent syntax.
@@ -95,6 +90,11 @@ public class EventCallbackBuilder<S, E> {
             this.actions = actions;
         }
 
+        /**
+         * @param events events to be posted with response body set. If you want to receive also
+         *               status code and headers pass instances of {@link RetrofitResponseEvent}.
+         * @return next stage of the builder
+         */
         public ResultExpireSetter<R, S, E> postResponseEvents(ResponseEvent<R>... events) {
             return new ResultExpireSetter(Arrays.asList(events), builder, actions);
         }

--- a/src/main/java/com/byoutline/eventcallback/ResponseEvent.java
+++ b/src/main/java/com/byoutline/eventcallback/ResponseEvent.java
@@ -1,5 +1,9 @@
 package com.byoutline.eventcallback;
 
+import retrofit.client.Header;
+
+import java.util.List;
+
 /**
  * Event that will have server response set.
  *
@@ -8,4 +12,8 @@ package com.byoutline.eventcallback;
 public interface ResponseEvent<R> {
 
     void setResponse(R response);
+
+    void setHeaders(List<Header> headers);
+
+    void setStatus(int status);
 }

--- a/src/main/java/com/byoutline/eventcallback/ResponseEvent.java
+++ b/src/main/java/com/byoutline/eventcallback/ResponseEvent.java
@@ -1,19 +1,14 @@
 package com.byoutline.eventcallback;
 
-import retrofit.client.Header;
-
-import java.util.List;
-
 /**
- * Event that will have server response set.
+ * Event that will have body of server response set. <br />
+ * If you need response status or headers take a look at
+ * {@link EventCallbackBuilder#onStatusCodes(Integer...)} or use
+ * {@link RetrofitResponseEvent} instead.
  *
  * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com> on 24.06.14.
  */
 public interface ResponseEvent<R> {
 
     void setResponse(R response);
-
-    void setHeaders(List<Header> headers);
-
-    void setStatus(int status);
 }

--- a/src/main/java/com/byoutline/eventcallback/ResponseEventImpl.java
+++ b/src/main/java/com/byoutline/eventcallback/ResponseEventImpl.java
@@ -1,9 +1,5 @@
 package com.byoutline.eventcallback;
 
-import retrofit.client.Header;
-
-import java.util.List;
-
 /**
  * Default implementation of {@link ResponseEvent}.
  *
@@ -11,9 +7,10 @@ import java.util.List;
  */
 public class ResponseEventImpl<R> implements ResponseEvent<R> {
     private R response;
-    private List<Header> headers;
-    private int status;
 
+    /**
+     * @return body of response returned from server
+     */
     public R getResponse() {
         return response;
     }
@@ -22,15 +19,4 @@ public class ResponseEventImpl<R> implements ResponseEvent<R> {
     public void setResponse(R response) {
         this.response = response;
     }
-
-    @Override
-    public void setHeaders(List<Header> headers) {
-        this.headers = headers;
-    }
-
-    @Override
-    public void setStatus(int status) {
-        this.status = status;
-    }
-
 }

--- a/src/main/java/com/byoutline/eventcallback/ResponseEventImpl.java
+++ b/src/main/java/com/byoutline/eventcallback/ResponseEventImpl.java
@@ -1,5 +1,9 @@
 package com.byoutline.eventcallback;
 
+import retrofit.client.Header;
+
+import java.util.List;
+
 /**
  * Default implementation of {@link ResponseEvent}.
  *
@@ -7,6 +11,8 @@ package com.byoutline.eventcallback;
  */
 public class ResponseEventImpl<R> implements ResponseEvent<R> {
     private R response;
+    private List<Header> headers;
+    private int status;
 
     public R getResponse() {
         return response;
@@ -16,4 +22,15 @@ public class ResponseEventImpl<R> implements ResponseEvent<R> {
     public void setResponse(R response) {
         this.response = response;
     }
+
+    @Override
+    public void setHeaders(List<Header> headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
 }

--- a/src/main/java/com/byoutline/eventcallback/RetrofitResponseEvent.java
+++ b/src/main/java/com/byoutline/eventcallback/RetrofitResponseEvent.java
@@ -1,0 +1,15 @@
+package com.byoutline.eventcallback;
+
+import retrofit.client.Header;
+
+import java.util.List;
+
+/**
+ * Event that will have server response body, headers and status.
+ */
+public interface RetrofitResponseEvent<R> extends ResponseEvent<R> {
+
+    void setHeaders(List<Header> headers);
+
+    void setStatus(int status);
+}

--- a/src/main/java/com/byoutline/eventcallback/RetrofitResponseEventImpl.java
+++ b/src/main/java/com/byoutline/eventcallback/RetrofitResponseEventImpl.java
@@ -1,0 +1,34 @@
+package com.byoutline.eventcallback;
+
+import retrofit.client.Header;
+
+import java.util.List;
+
+/**
+ * Default implementation of {@link RetrofitResponseEvent}.
+ *
+ * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com>
+ */
+public class RetrofitResponseEventImpl<R> extends ResponseEventImpl<R>
+        implements RetrofitResponseEvent<R> {
+    private List<Header> headers;
+    private int status;
+
+    @Override
+    public void setHeaders(List<Header> headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
+    public List<Header> getHeaders() {
+        return headers;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/byoutline/eventcallback/internal/EventPoster.java
+++ b/src/main/java/com/byoutline/eventcallback/internal/EventPoster.java
@@ -2,6 +2,7 @@ package com.byoutline.eventcallback.internal;
 
 import com.byoutline.eventcallback.IBus;
 import com.byoutline.eventcallback.ResponseEvent;
+import com.byoutline.eventcallback.RetrofitResponseEvent;
 import com.byoutline.eventcallback.internal.actions.AtomicBooleanSetter;
 import com.byoutline.eventcallback.internal.actions.CreateEvents;
 import com.byoutline.eventcallback.internal.actions.ResultEvents;
@@ -63,8 +64,11 @@ public class EventPoster {
     private <R> void postResponseEvents(R result, Response response, Iterable<ResponseEvent<R>> events) {
         for (ResponseEvent<R> event : events) {
             event.setResponse(result);
-            event.setHeaders(response.getHeaders());
-            event.setStatus(response.getStatus());
+            if(event instanceof RetrofitResponseEvent) {
+                RetrofitResponseEvent retrofitEvent = (RetrofitResponseEvent) event;
+                retrofitEvent.setHeaders(response.getHeaders());
+                retrofitEvent.setStatus(response.getStatus());
+            }
             bus.post(event);
         }
     }

--- a/src/main/java/com/byoutline/eventcallback/internal/EventPoster.java
+++ b/src/main/java/com/byoutline/eventcallback/internal/EventPoster.java
@@ -6,6 +6,7 @@ import com.byoutline.eventcallback.internal.actions.AtomicBooleanSetter;
 import com.byoutline.eventcallback.internal.actions.CreateEvents;
 import com.byoutline.eventcallback.internal.actions.ResultEvents;
 import com.byoutline.eventcallback.internal.actions.ScheduledActions;
+import retrofit.client.Response;
 
 /**
  * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com> on 26.06.14.
@@ -27,13 +28,13 @@ public class EventPoster {
         postAll(actions.multiSessionEvents);
     }
 
-    public <R> void executeResponseActions(ScheduledActions<ResultEvents<R>> actions, R response,
+    public <R> void executeResponseActions(ScheduledActions<ResultEvents<R>> actions, R result, Response response,
                                            boolean sameSession, boolean postNullResponse) {
         executeCommonActions(actions, sameSession);
-        if (response == null && !postNullResponse) {
+        if (result == null && !postNullResponse) {
             return;
         }
-        postResponseEvents(sameSession, postNullResponse, response, actions);
+        postResponseEvents(sameSession, postNullResponse, result, response, actions);
     }
 
     private static void setBools(Iterable<AtomicBooleanSetter> boolsToSet) {
@@ -52,16 +53,18 @@ public class EventPoster {
         }
     }
 
-    private <R> void postResponseEvents(boolean sameSession, boolean postNullResponse, R response, ScheduledActions<ResultEvents<R>> actions) {
+    private <R> void postResponseEvents(boolean sameSession, boolean postNullResponse, R result, Response response, ScheduledActions<ResultEvents<R>> actions) {
         if (sameSession) {
-            postResponseEvents(response, actions.sessionOnlyEvents.resultEvents);
+            postResponseEvents(result, response, actions.sessionOnlyEvents.resultEvents);
         }
-        postResponseEvents(response, actions.multiSessionEvents.resultEvents);
+        postResponseEvents(result, response, actions.multiSessionEvents.resultEvents);
     }
 
-    private <R> void postResponseEvents(R response, Iterable<ResponseEvent<R>> events) {
+    private <R> void postResponseEvents(R result, Response response, Iterable<ResponseEvent<R>> events) {
         for (ResponseEvent<R> event : events) {
-            event.setResponse(response);
+            event.setResponse(result);
+            event.setHeaders(response.getHeaders());
+            event.setStatus(response.getStatus());
             bus.post(event);
         }
     }

--- a/src/test/groovy/com/byoutline/eventcallback/EventCallbackSpec.groovy
+++ b/src/test/groovy/com/byoutline/eventcallback/EventCallbackSpec.groovy
@@ -1,17 +1,10 @@
 package com.byoutline.eventcallback
 
-import com.byoutline.eventcallback.ResponseEvent
 import com.byoutline.eventcallback.internal.EventPoster
-import com.byoutline.eventcallback.internal.actions.AtomicBooleanSetter
-import com.byoutline.eventcallback.internal.actions.CreateEvents
 import com.byoutline.eventcallback.internal.actions.ResultEvents
 import com.byoutline.eventcallback.internal.actions.ScheduledActions
-import retrofit.client.Header
-
-import javax.inject.Provider
-import com.google.gson.reflect.TypeToken
-import retrofit.Callback
 import retrofit.RetrofitError
+import retrofit.client.Header
 import retrofit.client.Response
 import spock.lang.Shared
 import spock.lang.Unroll
@@ -192,8 +185,6 @@ class EventCallbackSpec extends spock.lang.Specification {
 
 class StringResponseEvent implements ResponseEvent<String> {
     String response;
-
-    String response
     List<Header> headers
     int status
 


### PR DESCRIPTION
Adds ability to get response status and headers from event. To not break compatibility with existing code, old ResponseEvent interface was kept. This old interface can still be useful to document that API endpoint does not return any interesting headers or app should not check them (therefore I did NOT mark it as deprecated).
